### PR TITLE
Problem: errors in fty-metric-compute journal

### DIFF
--- a/src/fty-metric-compute.conf
+++ b/src/fty-metric-compute.conf
@@ -1,3 +1,3 @@
 # create runtime directories for fty-metric-compute
-d /var/lib/fty/bios-agent-cm 0755 bios root
-x /var/lib/fty/bios-agent-cm/*
+d /var/lib/fty/fty-metric-compute 0755 bios root
+x /var/lib/fty/fty-metric-compute/*


### PR DESCRIPTION
In journal I see this:
    ls: cannot access /var/lib/fty/fty-metric-compute/state.zpl: No such file or directory

In FS I see:
    # ls -la /var/lib/fty/fty-metric-compute          
    lrwxrwxrwx 1 root root 21 Mar 28 20:16 /var/lib/fty/fty-metric-compute -> ../bios/bios-agent-cm

Neither our current code nor compatibility with legacy version reference FTY/bios-agent-cm

Solution: rename path to service